### PR TITLE
Add utility to ensure local packages are up to date

### DIFF
--- a/example_app/Gemfile.lock
+++ b/example_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    packer (0.3.0)
+    packer (0.4.0)
       activesupport (~> 5)
       rack-proxy (~> 0.6.4)
 

--- a/lib/packer.rb
+++ b/lib/packer.rb
@@ -42,6 +42,7 @@ require 'packer/compiler'
 require 'packer/configuration'
 require 'packer/helper'
 require 'packer/instance'
+require 'packer/installer'
 require 'packer/manifest'
 require 'packer/dev_server'
 

--- a/lib/packer/compiler.rb
+++ b/lib/packer/compiler.rb
@@ -50,7 +50,6 @@ module Packer
     end
 
     def remove_compilation_digest
-      logger.info 'Calling'
       compilation_digest_path.delete if compilation_digest_path.exist?
     rescue Errno::ENOENT, Errno::ENOTDIR
     end

--- a/lib/packer/compiler.rb
+++ b/lib/packer/compiler.rb
@@ -45,7 +45,6 @@ module Packer
 
     def record_compilation_digest
       config.cache_path.mkpath
-      logger.info "#{watched_files_digest.inspect}"
       compilation_digest_path.write(watched_files_digest)
     end
 

--- a/lib/packer/installer.rb
+++ b/lib/packer/installer.rb
@@ -12,13 +12,11 @@ module Packer
     end
 
     def install
-      if stale?
-        record_package_digest
-        run_npm_install.tap do |success|
-          remove_package_digest unless success
-        end
-      else
-        true
+      return true if fresh?
+
+      record_package_digest
+      run_npm_install.tap do |success|
+        remove_package_digest unless success
       end
     end
 
@@ -37,11 +35,7 @@ module Packer
     end
 
     def package_file_digest
-      contents = if package_lock_path.exist?
-                   package_lock_path.read
-                 else
-                   ''
-                 end
+      contents = package_lock_path.exist? ? package_lock_path.read : ''
       Digest::SHA1.hexdigest(contents)
     end
 

--- a/lib/packer/installer.rb
+++ b/lib/packer/installer.rb
@@ -58,7 +58,7 @@ module Packer
 
     def run_npm_install
       logger.info 'Installing latest NPM packages (this may take a while)…'
-      sterr, stdout, status = Open3.capture3({}, 'npm install')
+      sterr, stdout, status = Open3.capture3('npm install')
 
       if status.success?
         logger.info 'Successfully installed packages'

--- a/lib/packer/installer.rb
+++ b/lib/packer/installer.rb
@@ -45,7 +45,6 @@ module Packer
     end
 
     def remove_package_digest
-      logger.info 'Calling'
       package_digest_path.delete if package_digest_path.exist?
     rescue Errno::ENOENT, Errno::ENOTDIR
     end

--- a/lib/packer/installer.rb
+++ b/lib/packer/installer.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'digest/sha1'
+
+module Packer
+  class Installer
+    delegate :logger, :config, to: :@packer
+
+    def initialize(packer)
+      @packer = packer
+    end
+
+    def install
+      if stale?
+        record_package_digest
+        run_npm_install.tap do |success|
+          remove_package_digest unless success
+        end
+      else
+        true
+      end
+    end
+
+    def fresh?
+      package_file_digest == last_package_digest
+    end
+
+    def stale?
+      !fresh?
+    end
+
+    private
+
+    def last_package_digest
+      package_digest_path.read if package_digest_path.exist?
+    end
+
+    def package_file_digest
+      contents = if package_lock_path.exist?
+                   package_lock_path.read
+                 else
+                   ''
+                 end
+      Digest::SHA1.hexdigest(contents)
+    end
+
+    def record_package_digest
+      config.cache_path.mkpath
+      package_digest_path.write(package_file_digest)
+    end
+
+    def remove_package_digest
+      logger.info 'Calling'
+      package_digest_path.delete if package_digest_path.exist?
+    rescue Errno::ENOENT, Errno::ENOTDIR
+    end
+
+    def run_npm_install
+      logger.info 'Installing latest NPM packages (this may take a while)…'
+      sterr, stdout, status = Open3.capture3({}, 'npm install')
+
+      if status.success?
+        logger.info 'Successfully installed packages'
+      else
+        logger.error "Installation failed:\n#{sterr}\n#{stdout}"
+      end
+    end
+
+    def package_lock_path
+      Pathname('package-lock.json')
+    end
+
+    def package_digest_path
+      config.cache_path.join(".last-package-digest-#{Packer.env}")
+    end
+  end
+end

--- a/lib/packer/instance.rb
+++ b/lib/packer/instance.rb
@@ -21,6 +21,10 @@ module Packer
       @compiler ||= Packer::Compiler.new self
     end
 
+    def installer
+      @installer ||= Packer::Installer.new self
+    end
+
     def config
       @config ||= Packer::Configuration.new self
     end

--- a/lib/packer/manifest.rb
+++ b/lib/packer/manifest.rb
@@ -6,7 +6,7 @@ module Packer
   class Manifest
     class MissingEntryError < StandardError; end
 
-    delegate :config, :compiler, :dev_server, to: :@packer
+    delegate :config, :installer, :compiler, :dev_server, to: :@packer
 
     def initialize(packer)
       @packer = packer
@@ -17,7 +17,10 @@ module Packer
     end
 
     def lookup(name)
-      compile if compiling?
+      if compiling?
+        install
+        compile
+      end
       find name
     end
 
@@ -29,6 +32,10 @@ module Packer
 
     def compiling?
       config.compile? && !dev_server.running?
+    end
+
+    def install
+      Packer.logger.tagged('Packer') { installer.install }
     end
 
     def compile

--- a/lib/packer/version.rb
+++ b/lib/packer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Packer
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
This PR adds the ability to install NPM packages before compiling, if compiling is enabled. On the first run, it will cache a digest of the package-lock.json file, and will only recompile if this changes.

Demo: https://github.com/simplybusiness/chopin/pull/8926

Start the rails server however you normally do and visit a backoffice page. The first page load, it will install the NPM dependencies and compile all the Webpack assets, the second time it will not since it'll know it's not necessary. Then you can add an NPM package (try `npm install --save lodash`) and load it again, whereby it'll see the change and install that new package.

@simplybusiness/limited-liability @simplybusiness/fully-responsive @gzzsound @jhonny-e-SB 