### PR TITLE
Add task to install NPM packages on precompile

### DIFF
--- a/lib/packer/version.rb
+++ b/lib/packer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Packer
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end

--- a/lib/tasks/packer.rake
+++ b/lib/tasks/packer.rake
@@ -1,6 +1,6 @@
 tasks = {
   "packer:info"                    => "Provides information on Packer's environment",
-  "packer:install"                 => "Installs and setup webpack with Npm",
+  "packer:install"                 => "Installs NPM packages",
   "packer:compile"                 => "Compiles webpack bundles based on environment",
   "packer:clobber"                 => "Removes the webpack compiled output directory",
   "packer:verify_install"          => "Verifies if Packer is installed"

--- a/lib/tasks/packer/compile.rake
+++ b/lib/tasks/packer/compile.rake
@@ -10,6 +10,7 @@ end
 
 def enhance_assets_precompile
   Rake::Task["assets:precompile"].enhance do
+    Rake::Task["packer:install"].invoke
     Rake::Task["packer:compile"].invoke
   end
 end
@@ -30,5 +31,5 @@ if Rake::Task.task_defined?("assets:precompile")
   skip_webpacker_precompile = %w(no false n f).include?(ENV["PACKER_PRECOMPILE"])
   enhance_assets_precompile unless skip_webpacker_precompile
 else
-  Rake::Task.define_task("assets:precompile" => ["packer:compile"])
+  Rake::Task.define_task("assets:precompile" => ["packer:install", "packer:compile"])
 end

--- a/lib/tasks/packer/install.rake
+++ b/lib/tasks/packer/install.rake
@@ -2,6 +2,6 @@ namespace :packer do
   desc 'Install NPM packages required for Packer asset compilation'
   task :install do
     $stdout.puts 'Installing NPM packages…'
-    system('npm install --quiet --no-progress')
+    system('npm install --production --quiet --no-progress')
   end
 end

--- a/lib/tasks/packer/install.rake
+++ b/lib/tasks/packer/install.rake
@@ -1,0 +1,7 @@
+namespace :packer do
+  desc 'Install NPM packages required for Packer asset compilation'
+  task :install do
+    $stdout.print 'Installing NPM packages… '
+    system('npm install --quiet --no-progress')
+  end
+end

--- a/lib/tasks/packer/install.rake
+++ b/lib/tasks/packer/install.rake
@@ -1,7 +1,7 @@
 namespace :packer do
   desc 'Install NPM packages required for Packer asset compilation'
   task :install do
-    $stdout.print 'Installing NPM packages… '
+    $stdout.puts 'Installing NPM packages…'
     system('npm install --quiet --no-progress')
   end
 end

--- a/lib/tasks/packer/verify_install.rake
+++ b/lib/tasks/packer/verify_install.rake
@@ -7,7 +7,7 @@ namespace :packer do
       $stdout.puts "Packer is installed 🎉 🍰 🎉"
       $stdout.puts "Using #{Packer.config.config_path} file for setting up webpack paths"
     else
-      $stderr.puts "Configuration config/packer.yml file not found. \n"\
+      $stderr.puts "Configuration #{Packer.config.config_path} file not found. \n"\
            "Make sure packer:install is run successfully before " \
            "running dependent tasks"
       exit!


### PR DESCRIPTION
Adds NPM install task to replace the recently removed Yarn stuff.

Rails by default assumes that you're using Yarn, even if you have absolutely no Webpack or general Node assets, so when you run `assets:precompile`, it automatically installs the NPM packages. We do not want it doing that as it can interfere with the packages managed by NPM.

@simplybusiness/fully-responsive 