### PR TITLE
Allow overriding packer config path in Sinatra initialiser

### DIFF
--- a/lib/packer/sinatra.rb
+++ b/lib/packer/sinatra.rb
@@ -9,6 +9,7 @@ module Packer
     def self.registered(app)
       Packer.instance = Packer::Instance.new(
         root_path: app.settings.root,
+        config_path: app.settings.respond_to?(:packer_config_path) ? app.settings.packer_config_path : nil,
         environment: app.settings.environment
       )
       app.helpers Packer::Helper

--- a/lib/packer/version.rb
+++ b/lib/packer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Packer
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end


### PR DESCRIPTION
Seedy requires setting an initialiser path manually due to the fact it has multiple sites in one repo, so this PR allows you to set a `packer_config_path` on the app and use that for finding the configuration file.

@simplybusiness/fully-responsive 