### PR TITLE
Add PACKER_NO_COMPILE option

### DIFF
--- a/lib/packer/compiler.rb
+++ b/lib/packer/compiler.rb
@@ -12,6 +12,8 @@ module Packer
     end
 
     def compile
+      return true if no_compile?
+
       if stale?
         record_compilation_digest
         run_webpack.tap do |success|
@@ -20,6 +22,10 @@ module Packer
       else
         true
       end
+    end
+
+    def no_compile?
+      ENV['PACKER_NO_COMPILE'].present?
     end
 
     # Returns true if all the compiled packs are up to date with the underlying asset files.

--- a/lib/packer/version.rb
+++ b/lib/packer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Packer
-  VERSION = '0.6.1'
+  VERSION = '0.7.0'
 end


### PR DESCRIPTION
Adds an option to skip compiling based on the existence of an environment variable called `PACKER_NO_COMPILE`.

@ewhorton @pdawczak 