### PR TITLE
upgrade versioning logic for dependabot

### DIFF
--- a/lib/packer/version.rb
+++ b/lib/packer/version.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
 module Packer
-  VERSION = '0.7.0'
+  VERSION = '0.7.0' # rubocop:disable Style/MutableConstant
+
+  # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
+  VERSION << '.' << ENV['GEM_PRE_RELEASE'].strip \
+  unless ENV.fetch('GEM_PRE_RELEASE', '').strip.empty?
 end

--- a/packer.gemspec
+++ b/packer.gemspec
@@ -4,15 +4,9 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'packer/version'
 
-gem_version = if ENV['GEM_PRE_RELEASE'].nil? || ENV['GEM_PRE_RELEASE'].empty?
-                Packer::VERSION
-              else
-                "#{Packer::VERSION}.#{ENV['GEM_PRE_RELEASE']}"
-              end
-
 Gem::Specification.new do |spec|
   spec.name          = 'packer'
-  spec.version       = gem_version
+  spec.version       = Packer::VERSION
   spec.authors       = ['Leslie Hoare']
   spec.email         = ['iam@lesleh.co.uk']
 


### PR DESCRIPTION
upgrade gemstash versioning logic so that dependabot can automatically
manage versions of dependencies in the gemspec

dependabot is used to create automatic PRs for security vulnerabilities