### PR TITLE
upgrade versioning logic for dependabot

### DIFF
--- a/lib/packer/version.rb
+++ b/lib/packer/version.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
 module Packer
-  VERSION = '0.7.0'
+  base = '0.7.0'
+
+  # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
+  VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"
 end

--- a/lib/packer/version.rb
+++ b/lib/packer/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Packer
-  base = '0.7.0'
+  base = '0.7.1'
 
   # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
   VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"

--- a/packer.gemspec
+++ b/packer.gemspec
@@ -4,15 +4,9 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'packer/version'
 
-gem_version = if ENV['GEM_PRE_RELEASE'].nil? || ENV['GEM_PRE_RELEASE'].empty?
-                Packer::VERSION
-              else
-                "#{Packer::VERSION}.#{ENV['GEM_PRE_RELEASE']}"
-              end
-
 Gem::Specification.new do |spec|
   spec.name          = 'packer'
-  spec.version       = gem_version
+  spec.version       = Packer::VERSION
   spec.authors       = ['Leslie Hoare']
   spec.email         = ['iam@lesleh.co.uk']
 


### PR DESCRIPTION
upgrade gemstash versioning logic so that dependabot can automatically
manage versions of dependencies in the gemspec

dependabot is used to create automatic PRs for security vulnerabilities