### PR TITLE
Yarn install from frozen lockfile

### DIFF
--- a/lib/packer/version.rb
+++ b/lib/packer/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Packer
-  base = '0.7.1'
+  base = '0.7.2'
 
   # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
   VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"

--- a/lib/tasks/packer/install.rake
+++ b/lib/tasks/packer/install.rake
@@ -4,6 +4,6 @@ namespace :packer do
   desc 'Install Yarn packages required for Packer asset compilation'
   task :install do
     $stdout.puts 'Installing Yarn packages…'
-    system('yarn install --no-progress --non-interactive')
+    system('yarn install --frozen-lockfile --no-progress --non-interactive')
   end
 end


### PR DESCRIPTION
Please review: @tgallacher 

This rake task is run whenever we run 'assets:precompile' in Chopin.

Should we also only install from the frozen lockfile when we do this as part of booting up Chopin?